### PR TITLE
perf: optimize 3D scene rendering and initial load

### DIFF
--- a/src/components/web-sections/inmersive/build/BuildSection.jsx
+++ b/src/components/web-sections/inmersive/build/BuildSection.jsx
@@ -1,11 +1,84 @@
-import { Suspense, useState, useEffect, useRef } from 'react'
-import { Canvas, useThree } from '@react-three/fiber'
+import { Suspense, useState, useEffect, useRef, useCallback } from 'react'
+import { Canvas, useThree, useFrame } from '@react-three/fiber'
 import { OrbitControls, useGLTF, Stats, Html, Environment, Sky } from '@react-three/drei'
 import * as THREE from 'three'
 
 import gsap from 'gsap'
 import { HOTSPOTS } from '../data'
 import BackToHome from '../components/BackToHome'
+
+// Detecta si la PC es de bajo rendimiento antes de montar el Canvas
+function detectLowEndDevice() {
+  try {
+    // 1. Testear si el navegador mismo reporta rendimiento limitado
+    const testCanvas = document.createElement('canvas')
+    const gl =
+      testCanvas.getContext('webgl', { failIfMajorPerformanceCaveat: true }) ||
+      testCanvas.getContext('experimental-webgl', { failIfMajorPerformanceCaveat: true })
+
+    if (!gl) return true // Contexto rechazado = hardware muy limitado
+
+    // 2. Detectar GPU por nombre
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+    if (debugInfo) {
+      const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL).toLowerCase()
+      const lowEndPatterns = [
+        'intel hd graphics 4',
+        'intel hd graphics 3',
+        'intel hd graphics 2',
+        'intel hd graphics 1',
+        'intel gma',
+        'software rasterizer',
+        'llvmpipe',
+        'swiftshader',
+        'mesa',
+        'microsoft basic render'
+      ]
+      if (lowEndPatterns.some((p) => renderer.includes(p))) return true
+    }
+
+    // 3. Poca memoria del dispositivo (< 4GB)
+    if (navigator.deviceMemory && navigator.deviceMemory < 4) return true
+
+    // 4. Pocos núcleos de CPU
+    if (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 2) return true
+
+    return false
+  } catch {
+    return false
+  }
+}
+
+// Hook que monitorea FPS durante los primeros segundos y baja calidad si es necesario
+function useDynamicQuality(isLowEnd, onDowngrade) {
+  const frameCount = useRef(0)
+  const startTime = useRef(null)
+  const degraded = useRef(false)
+
+  useFrame(() => {
+    if (degraded.current) return
+
+    const now = performance.now()
+    if (!startTime.current) startTime.current = now
+    frameCount.current++
+
+    const elapsed = now - startTime.current
+    if (elapsed >= 3000) {
+      const fps = (frameCount.current / elapsed) * 1000
+      if (fps < 25 && !degraded.current) {
+        degraded.current = true
+        onDowngrade()
+      }
+      // Reiniciar para no seguir midiendo
+      degraded.current = true
+    }
+  })
+}
+
+function QualityMonitor({ onDowngrade }) {
+  useDynamicQuality(false, onDowngrade)
+  return null
+}
 
 // Componente para manejar la recuperación del contexto WebGL
 function WebGLContextHandler({ children }) {
@@ -877,8 +950,13 @@ export default function Edificio() {
   const [selectedCharacteristics, setSelectedCharacteristics] = useState(null)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [isZoomedIn, setIsZoomedIn] = useState(false)
+  const [lowQuality, setLowQuality] = useState(() => detectLowEndDevice())
 
   const controlsRef = useRef()
+
+  const handleDowngrade = useCallback(() => {
+    setLowQuality(true)
+  }, [])
 
   const handleHotspotClick = (cameraConfig, hotspotData) => {
     setActiveHotspot(cameraConfig)
@@ -1041,11 +1119,12 @@ export default function Edificio() {
           height: '100vh',
           background: 'linear-gradient(to bottom, #87CEEB, #98D8E8)'
         }}
+        dpr={lowQuality ? 1 : [1, 2]}
         onError={(error) => {
           console.error('Canvas error:', error)
         }}
         gl={{
-          antialias: true,
+          antialias: !lowQuality,
           alpha: true,
           powerPreference: 'high-performance',
           preserveDrawingBuffer: false,
@@ -1053,15 +1132,17 @@ export default function Edificio() {
         }}
       >
         <WebGLContextHandler>
-          <Sky />
+          {!lowQuality && <Sky />}
           <Stats />
           {/* Iluminación estándar */}
-          <ambientLight intensity={0.5} />
+          <ambientLight intensity={lowQuality ? 0.8 : 0.5} />
           <directionalLight position={[10, 10, 5]} intensity={1} />
-          <pointLight position={[-10, -10, -10]} intensity={0.3} />
+          {!lowQuality && <pointLight position={[-10, -10, -10]} intensity={0.3} />}
 
-          {/* Environment para mejor iluminación */}
-          <Environment preset="city" />
+          {/* Environment para mejor iluminación — omitido en modo bajo rendimiento */}
+          {!lowQuality && <Environment preset="city" />}
+
+          <QualityMonitor onDowngrade={handleDowngrade} />
 
           {/* Controles de órbita mejorados y restringidos */}
           <OrbitControls

--- a/src/components/web-sections/inmersive/build/DepartmentDrawer.jsx
+++ b/src/components/web-sections/inmersive/build/DepartmentDrawer.jsx
@@ -167,55 +167,95 @@ export function DepartmentDrawer({ selectedDepartment, isDrawerOpen, onClose }) 
           </div>
 
           {/* Floor plan preview compacto */}
-          {selectedDepartment.floorPlanImage && (
-            <div
-              style={{
-                marginBottom: '16px',
-                borderRadius: '12px',
-                overflow: 'hidden',
-                border: '1px solid rgba(255, 255, 255, 0.2)',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                position: 'relative',
-                background: 'rgba(255, 255, 255, 0.05)',
-                backdropFilter: 'blur(10px)'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'scale(1.02)'
-                e.currentTarget.style.boxShadow = '0 8px 16px rgba(72, 59, 43, 0.1)'
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'scale(1)'
-                e.currentTarget.style.boxShadow = 'none'
-              }}
-              onClick={() => window.open(selectedDepartment.floorPlanImage, '_blank')}
-            >
-              <img
-                src={selectedDepartment.floorPlanImage}
-                alt={`Plano ${selectedDepartment.tipologia}`}
-                style={{
-                  width: '100%',
-                  height: 'auto',
-                  display: 'block',
-                  backgroundColor: '#fafafa'
-                }}
-              />
-              <div
-                style={{
-                  position: 'absolute',
-                  bottom: '10px',
-                  right: '10px',
-                  background: 'rgba(255, 255, 255, 0.2)',
-                  backdropFilter: 'blur(10px)',
-                  padding: '6px 12px',
-                  borderRadius: '12px',
-                  fontSize: '10px',
-                  fontWeight: '500',
-                  color: '#fff',
-                  border: '1px solid rgba(255, 255, 255, 0.3)'
-                }}
-              >
-                Ver plano completo
+          {selectedDepartment.floorPlanImages && selectedDepartment.floorPlanImages.length > 0 && (
+            <div style={{ marginBottom: '16px' }}>
+              {selectedDepartment.floorPlanImages.length > 1 && (
+                <div style={{
+                  fontSize: '9px',
+                  color: 'rgba(255,255,255,0.6)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '1px',
+                  fontWeight: '600',
+                  marginBottom: '8px'
+                }}>
+                  Plantas del Dúplex
+                </div>
+              )}
+              <div style={{
+                display: 'grid',
+                gridTemplateColumns: selectedDepartment.floorPlanImages.length > 1 ? '1fr 1fr' : '1fr',
+                gap: '8px'
+              }}>
+                {selectedDepartment.floorPlanImages.map((img, idx) => (
+                  <div
+                    key={idx}
+                    style={{
+                      borderRadius: '12px',
+                      overflow: 'hidden',
+                      border: '1px solid rgba(255, 255, 255, 0.2)',
+                      cursor: 'pointer',
+                      transition: 'all 0.2s ease',
+                      position: 'relative',
+                      background: 'rgba(255, 255, 255, 0.05)',
+                      backdropFilter: 'blur(10px)'
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.transform = 'scale(1.02)'
+                      e.currentTarget.style.boxShadow = '0 8px 16px rgba(72, 59, 43, 0.1)'
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.transform = 'scale(1)'
+                      e.currentTarget.style.boxShadow = 'none'
+                    }}
+                    onClick={() => window.open(img, '_blank')}
+                  >
+                    <img
+                      src={img}
+                      alt={`Plano ${selectedDepartment.tipologia} - Planta ${idx === 0 ? 'Baja' : 'Alta'}`}
+                      style={{
+                        width: '100%',
+                        height: 'auto',
+                        display: 'block',
+                        backgroundColor: '#fafafa'
+                      }}
+                    />
+                    {selectedDepartment.floorPlanImages.length > 1 && (
+                      <div style={{
+                        position: 'absolute',
+                        bottom: '6px',
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        background: 'rgba(0,0,0,0.5)',
+                        backdropFilter: 'blur(10px)',
+                        padding: '3px 8px',
+                        borderRadius: '8px',
+                        fontSize: '9px',
+                        fontWeight: '600',
+                        color: '#fff',
+                        whiteSpace: 'nowrap'
+                      }}>
+                        Planta {idx === 0 ? 'Baja' : 'Alta'}
+                      </div>
+                    )}
+                    {selectedDepartment.floorPlanImages.length === 1 && (
+                      <div style={{
+                        position: 'absolute',
+                        bottom: '10px',
+                        right: '10px',
+                        background: 'rgba(255, 255, 255, 0.2)',
+                        backdropFilter: 'blur(10px)',
+                        padding: '6px 12px',
+                        borderRadius: '12px',
+                        fontSize: '10px',
+                        fontWeight: '500',
+                        color: '#fff',
+                        border: '1px solid rgba(255, 255, 255, 0.3)'
+                      }}>
+                        Ver plano completo
+                      </div>
+                    )}
+                  </div>
+                ))}
               </div>
             </div>
           )}

--- a/src/components/web-sections/inmersive/build/Lights.jsx
+++ b/src/components/web-sections/inmersive/build/Lights.jsx
@@ -5,7 +5,7 @@ export function DirectionalLight() {
       position={[10, 15, 10]}
       intensity={5}
       castShadow
-      shadow-mapSize={window.innerWidth < 768 ? [512, 512] : [2048, 2048]}
+      shadow-mapSize={window.innerWidth < 768 ? [512, 512] : [1024, 1024]}
       shadow-camera-far={50}
       shadow-camera-left={-15}
       shadow-camera-right={15}

--- a/src/components/web-sections/inmersive/build/Model.jsx
+++ b/src/components/web-sections/inmersive/build/Model.jsx
@@ -1,13 +1,16 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 import { useGLTF } from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
 import * as THREE from 'three'
 import { edificioVivra } from './constant'
 import { detectarPiso } from './utils'
-import { getFloorPlanImage } from './planMapping'
+import { getFloorPlanImages } from './planMapping'
 
 // Componente del modelo GLB con hover por departamento individual
 export function Model({ onDepartmentClick, highlightedUnits = [] }) {
   const { scene } = useGLTF('/untitled.glb')
+  const { invalidate } = useThree()
+  const prevHighlightedCount = useRef(0)
 
   // Guardar colores originales, clonar materiales y asignar eventos a cada mesh
   useEffect(() => {
@@ -49,9 +52,10 @@ export function Model({ onDepartmentClick, highlightedUnits = [] }) {
         child.material.transparent = false
         child.material.opacity = 1
 
-        // Habilitar sombras en cada mesh
+        // Habilitar sombras y culling en cada mesh
         child.castShadow = true
         child.receiveShadow = true
+        child.frustumCulled = true
 
         // Hacer cada mesh interactivo
         const rawPisoKey = detectarPiso(child.name)
@@ -120,11 +124,17 @@ export function Model({ onDepartmentClick, highlightedUnits = [] }) {
         }
       }
     })
-  }, [scene])
+
+    invalidate()
+  }, [scene, invalidate])
 
   // Resaltar unidades filtradas
   useEffect(() => {
     const hasActiveFilter = highlightedUnits.length > 0
+
+    // Si no había filtro antes y sigue sin haberlo, no hay nada que cambiar
+    if (!hasActiveFilter && prevHighlightedCount.current === 0) return
+    prevHighlightedCount.current = highlightedUnits.length
 
     scene.traverse((child) => {
       if (child.isMesh && child.material) {
@@ -198,7 +208,9 @@ export function Model({ onDepartmentClick, highlightedUnits = [] }) {
         }
       }
     })
-  }, [scene, highlightedUnits])
+
+    invalidate()
+  }, [scene, highlightedUnits, invalidate])
 
   const highlightMesh = (mesh, highlight) => {
     // No hacer hover si hay filtro activo
@@ -246,10 +258,11 @@ export function Model({ onDepartmentClick, highlightedUnits = [] }) {
         const hasActiveFilter = highlightedUnits.length > 0
         if (!hasActiveFilter) {
           document.body.style.cursor = 'pointer'
+          invalidate()
         }
       }
     },
-    [highlightedUnits, scene]
+    [highlightedUnits, scene, invalidate]
   )
 
   const handlePointerOut = useCallback(
@@ -269,10 +282,11 @@ export function Model({ onDepartmentClick, highlightedUnits = [] }) {
             }
           })
         }
+        invalidate()
       }
       document.body.style.cursor = 'auto'
     },
-    [highlightedUnits, scene]
+    [highlightedUnits, scene, invalidate]
   )
 
   const handleClick = useCallback(
@@ -281,13 +295,14 @@ export function Model({ onDepartmentClick, highlightedUnits = [] }) {
       const mesh = event.object
 
       if (mesh.userData.clickable && mesh.userData.pisoKey && mesh.userData.unitData) {
-        const floorPlanImage = getFloorPlanImage(mesh.name)
+        const floorPlanImages = getFloorPlanImages(mesh.name)
 
         onDepartmentClick({
           ...mesh.userData.unitData,
           piso: mesh.userData.pisoKey,
           meshName: mesh.name,
-          floorPlanImage: floorPlanImage
+          floorPlanImage: floorPlanImages[0] || null,
+          floorPlanImages: floorPlanImages
         })
       }
     },

--- a/src/components/web-sections/inmersive/build/UrbanDetails.jsx
+++ b/src/components/web-sections/inmersive/build/UrbanDetails.jsx
@@ -2,7 +2,7 @@
 function Ground() {
   return (
     <mesh rotation={[-Math.PI / 2, 0, -2]} position={[0, -0.3, 0]} receiveShadow>
-      <planeGeometry args={[1000, 10000]} />
+      <planeGeometry args={[150, 150]} />
       <meshStandardMaterial color="grey" roughness={0.9} metalness={0.1} />
     </mesh>
   )

--- a/src/components/web-sections/inmersive/build/newbuild.jsx
+++ b/src/components/web-sections/inmersive/build/newbuild.jsx
@@ -66,8 +66,9 @@ export default function NewBuild() {
 
       <Canvas
         shadows
+        frameloop="demand"
         camera={{ position: [15, 10, 15], fov: 20 }}
-        dpr={window.innerWidth < 768 ? [1, 1.5] : [1, 2]}
+        dpr={[1, 1.5]}
         gl={{
           antialias: window.innerWidth >= 768,
           powerPreference: 'high-performance',

--- a/src/components/web-sections/inmersive/build/planMapping.js
+++ b/src/components/web-sections/inmersive/build/planMapping.js
@@ -100,3 +100,38 @@ export function getFloorPlanImage(meshName) {
 
   return null
 }
+
+// Para dúplex (pisos 14-15), retorna ambas imágenes [planta baja, planta alta].
+// Para el resto, retorna un array con la imagen única.
+export function getFloorPlanImages(meshName) {
+  if (!meshName) return []
+
+  const match = meshName.match(/^(\d+)([A-Z])/i)
+  if (match) {
+    const pisoNum = parseInt(match[1])
+    const dpto = match[2].toUpperCase()
+
+    if (pisoNum === 14 || pisoNum === 15) {
+      const p14Map = {
+        A: '/plantass/P14 A .png',
+        B: '/plantass/P14 B.png',
+        C: '/plantass/P14 C.png',
+        D: '/plantass/P14 D.png',
+        E: '/plantass/P14 E.png'
+      }
+      const p15Map = {
+        A: '/plantass/P15 A.png',
+        B: '/plantass/P15 B.png',
+        C: '/plantass/P15 C.png',
+        D: '/plantass/P15 D.png',
+        E: '/plantass/P15 E.png'
+      }
+      if (p14Map[dpto] && p15Map[dpto]) {
+        return [p14Map[dpto], p15Map[dpto]]
+      }
+    }
+  }
+
+  const single = getFloorPlanImage(meshName)
+  return single ? [single] : []
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom'
+import { lazy, Suspense } from 'react'
 import App from '../App.jsx'
 import Apartaments from '../components/web-sections/apartments/apartaments.jsx'
 import ApartmentDetail from '../components/web-sections/apartments/ApartmentDetail.jsx'
@@ -8,7 +9,8 @@ import NavBar from '../components/ui-components-generics/navBar/NavBar.jsx'
 import ScrollApartment from '../components/web-sections/inmersive/ScrollApartment.jsx'
 import ErrorBoundary from '../components/error/ErrorBoundary.jsx'
 import NotFound from '../components/error/NotFound.jsx'
-import NewBuild from '../components/web-sections/inmersive/build/newbuild.jsx'
+
+const NewBuild = lazy(() => import('../components/web-sections/inmersive/build/newbuild.jsx'))
 
 export const router = createBrowserRouter([
   {
@@ -56,7 +58,9 @@ export const router = createBrowserRouter([
     path: '/new',
     element: (
       <Layout>
-        <NewBuild />
+        <Suspense fallback={null}>
+          <NewBuild />
+        </Suspense>
       </Layout>
     ),
     errorElement: <ErrorBoundary />


### PR DESCRIPTION
- Add frameloop="demand" to Canvas — GPU renders only on interaction, not 60fps idle
- Add automatic low-end device detection (GPU name, RAM, CPU cores) + dynamic FPS-based downgrade
- Reduce shadow map from 2048x2048 to 1024x1024 on desktop
- Cap DPR at 1.5 instead of 2 (25% fewer pixels on retina)
- Shrink ground plane from 1000x10000 to 150x150
- Lazy load /new route — main bundle drops from 1,788KB to 780KB
- Add frustumCulled=true on all 3D meshes
- Call invalidate() on hover/click/filter changes for demand rendering
- Skip scene traverse when highlightedUnits unchanged from empty