### PR TITLE
feat: disponibilidad subdomain via iframe

### DIFF
--- a/src/components/web-sections/disponibilidad/Disponibilidad.jsx
+++ b/src/components/web-sections/disponibilidad/Disponibilidad.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function Disponibilidad() {
+  return (
+    <iframe
+      src="https://majaxu.github.io/listado-vivra/cotizador-vivra.html"
+      title="Disponibilidad Vivra Güemes"
+      style={{ width: '100%', height: '100vh', border: 'none', display: 'block' }}
+      loading="lazy"
+    />
+  )
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -9,6 +9,7 @@ import ScrollApartment from '../components/web-sections/inmersive/ScrollApartmen
 import ErrorBoundary from '../components/error/ErrorBoundary.jsx'
 import NotFound from '../components/error/NotFound.jsx'
 import NewBuild from '../components/web-sections/inmersive/build/newbuild.jsx'
+import Disponibilidad from '../components/web-sections/disponibilidad/Disponibilidad.jsx'
 
 export const router = createBrowserRouter([
   {
@@ -69,6 +70,11 @@ export const router = createBrowserRouter([
         <Roadmap />
       </Layout>
     ),
+    errorElement: <ErrorBoundary />
+  },
+  {
+    path: '/disponibilidad',
+    element: <Disponibilidad />,
     errorElement: <ErrorBoundary />
   },
   {

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
     {
       "source": "/(.*)",
       "has": [{"type": "host", "value": "disponibilidad.vivraguemes.com.ar"}],
-      "destination": "https://majaxu.github.io/listado-vivra/cotizador-vivra.html"
+      "destination": "/disponibilidad"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Cambios

- Nueva página `Disponibilidad.jsx` que embebe el cotizador externo en un iframe fullscreen
- Nueva ruta `/disponibilidad` en el router (sin Layout ni NavBar)
- `vercel.json` actualizado: el subdominio `disponibilidad.vivraguemes.com.ar` reescribe internamente a `/disponibilidad` en vez de proxiar a la URL externa (que requiere plan Pro)

## Resultado

`disponibilidad.vivraguemes.com.ar` → muestra el cotizador de GitHub Pages sin cambiar la URL del browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)